### PR TITLE
[bugfix] Pin the Husky version and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,31 @@
-# ice-box
+[![Build Status](https://travis-ci.org/Addepar/addepar-ember-toolbox.svg?branch=master)](https://travis-ci.org/Addepar/addepar-ember-toolbox)
 
-This README outlines the details of collaborating on this Ember addon.
+# @addepar/ember-toolbox
+
+This is the official Addepar Ember Toolbox! It provides a number of things for Addepar
+Ember projects, including:
+
+* Useful polyfills of Ember functionality for older versions of Ember
+  * The `(hash)` helper
+  * The `(concat)` helper
+  * `Ember.assign`
+* Ember commands to run Addepar's automated linting and formatting
+  * `ember adde-lint --javascript --sass --file-names`: Runs our linting checks against
+    the specified files. If no files are specified, runs them against the entire repo.
+  * `ember adde-format`: Formats the files specified, or if none are specified formats
+    the entire repo.
+  * `ember adde-pre-commit`: Runs our formatting and linting checks against staged
+    changes
+
+Installing this addon will also add our styleguides as dependencies, set up a pre-commit
+hook to format/lint changed files before commits using [Husky](https://github.com/typicode/husky/),
+and automatically format the repo its installed in.
 
 ## Installation
 
-* `git clone <repository-url>` this repository
-* `cd ice-box`
-* `npm install`
+```
+ember install @addepar/ember-toolbox
+```
 
 ## Running
 

--- a/blueprints/@addepar/ember-toolbox/index.js
+++ b/blueprints/@addepar/ember-toolbox/index.js
@@ -38,7 +38,7 @@ module.exports = {
     updateTravisYml(root);
 
     return this.addPackagesToProject([
-      { name: 'husky' },
+      { name: 'husky', target: '^0.14.3' },
       { name: '@addepar/eslint-config' },
       { name: '@addepar/prettier-config' },
       { name: '@addepar/sass-lint-config' },

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -2,6 +2,8 @@ const fs = require('fs-extra');
 const execa = require('execa');
 const walkSync = require('walk-sync');
 
+const NON_STANDARD_FILE_NAMES = ['.DS_Store', 'README.md', 'README', 'LICENSE.md', 'LICENSE'];
+
 const STANDARD_APP_FILES = ['index.js', 'ember-cli-build.js', 'testem.js'];
 
 const STANDARD_APP_PATHS = [
@@ -50,11 +52,10 @@ function lintFileNames(paths = []) {
   // SASS partials) and folders may begin with @ to account for scopes
   let dasherizedNamesOnly = /^(@?[a-z0-9-]+\/)*(_?[a-z0-9-.]+)?$/;
 
-  // Match hidden file names such as .DS_Store
-  let hiddenFileNames = /^\..*$/;
+  let nonStardardFileNamesRegex = new RegExp(NON_STANDARD_FILE_NAMES.join('|'));
 
   let matches = paths.filter(
-    path => !path.match(dasherizedNamesOnly) && !path.match(hiddenFileNames)
+    path => !path.match(dasherizedNamesOnly) && !path.match(nonStardardFileNamesRegex)
   );
 
   if (matches.length > 0) {


### PR DESCRIPTION
Pins the Husky version so that we don't accidentally get breakage
(1.0.0 is coming out soon and changes the API) and update the
README with a better description. Also fixes a file-name-lint
bug (can't commit changes to README or LICENSE)