### PR TITLE
[bugfix] Ensure only Ember filenames are linted

### DIFF
--- a/lib/lint.js
+++ b/lib/lint.js
@@ -2,8 +2,6 @@ const fs = require('fs-extra');
 const execa = require('execa');
 const walkSync = require('walk-sync');
 
-const NON_STANDARD_FILE_NAMES = ['.DS_Store', 'README.md', 'README', 'LICENSE.md', 'LICENSE'];
-
 const STANDARD_APP_FILES = ['index.js', 'ember-cli-build.js', 'testem.js'];
 
 const STANDARD_APP_PATHS = [
@@ -41,22 +39,22 @@ function lintFileNames(paths = []) {
   if (paths.length === 0) {
     for (let path of STANDARD_APP_PATHS) {
       if (fs.existsSync(`${root}/${path}`)) {
-        paths.push(...walkSync(`${root}/${path}`));
+        paths.push(...walkSync(`${root}/${path}`).map(p => `${path}/${p}`));
       }
     }
   } else {
-    paths = paths.map(p => p.replace(`${root}/`, ''));
+    paths = paths.map(p => p.replace(`${root}/`, '')).filter(p => {
+      let appPathsPrefix = new RegExp(`^(${STANDARD_APP_PATHS.join('|')})`);
+
+      return p.match(appPathsPrefix) || STANDARD_APP_FILES.includes(p);
+    });
   }
 
   // Accepts dasherized folder and file names. Files may begin with _ (to accomodate
   // SASS partials) and folders may begin with @ to account for scopes
   let dasherizedNamesOnly = /^(@?[a-z0-9-]+\/)*(_?[a-z0-9-.]+)?$/;
 
-  let nonStardardFileNamesRegex = new RegExp(NON_STANDARD_FILE_NAMES.join('|'));
-
-  let matches = paths.filter(
-    path => !path.match(dasherizedNamesOnly) && !path.match(nonStardardFileNamesRegex)
-  );
+  let matches = paths.filter(path => !path.match(dasherizedNamesOnly) && path !== '.DS_Store');
 
   if (matches.length > 0) {
     return [


### PR DESCRIPTION
The current whitelisting strategy is too restrictive, there are lots
of other files in repos that can get sucked in. This converts us to only
checking files in the ember paths.

Also fixes a bug where we don't include the full path for filenames
when linting.