### PR TITLE
Use Husky at ^3.0.3

### DIFF
--- a/blueprints/@addepar/ember-toolbox/index.js
+++ b/blueprints/@addepar/ember-toolbox/index.js
@@ -1,12 +1,24 @@
 const fs = require('fs-extra');
 const { formatAll } = require('../../../lib/format');
 
-function updatePackageJson(root) {
+function updatePackageJson(root, ui) {
   let packageJson = fs.readJsonSync(`${root}/package.json`);
 
   packageJson.scripts = packageJson.scripts || {};
 
-  packageJson.scripts.precommit = 'ember adde-pre-commit';
+  packageJson.husky = packageJson.husky || {};
+  packageJson.husky.hooks = packageJson.husky.hooks || {};
+  if (packageJson.husky.hooks['pre-commit']) {
+    let existingHook = packageJson.husky.hooks['pre-commit'];
+    ui.writeWarnLine(
+      `Skipping addition of husky pre-commit hook because one is already present: "${existingHook}"`
+    );
+    ui.writeWarnLine(
+      'You should manually modify the husky pre-commit hook to run "ember adde-pre-commit"'
+    );
+  } else {
+    packageJson.husky.hooks['pre-commit'] = 'ember adde-pre-commit';
+  }
 
   packageJson.scripts.lint = 'ember adde-lint';
   packageJson.scripts['lint:js'] = 'ember adde-lint --javascript';
@@ -34,11 +46,11 @@ module.exports = {
   afterInstall() {
     let { ui, root } = this.project;
 
-    updatePackageJson(root);
+    updatePackageJson(root, ui);
     updateTravisYml(root);
 
     return this.addPackagesToProject([
-      { name: 'husky', target: '^0.14.3' },
+      { name: 'husky', target: '^3.0.3' },
       { name: '@addepar/eslint-config' },
       { name: '@addepar/prettier-config' },
       { name: '@addepar/sass-lint-config' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,9 +1307,9 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.3, broccoli-debug@^0.6.4, broccoli-de
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
-"broccoli-esdoc@git+https://github.com/pzuraq/broccoli-esdoc.git#93c5d0042fd751cec468fb01687c7f4e1aa447ea":
+"broccoli-esdoc@https://github.com/pzuraq/broccoli-esdoc.git#93c5d0042fd751cec468fb01687c7f4e1aa447ea":
   version "0.0.1"
-  resolved "git+https://github.com/pzuraq/broccoli-esdoc.git#93c5d0042fd751cec468fb01687c7f4e1aa447ea"
+  resolved "https://github.com/pzuraq/broccoli-esdoc.git#93c5d0042fd751cec468fb01687c7f4e1aa447ea"
   dependencies:
     broccoli-caching-writer "^3.0.3"
     esdoc "https://github.com/pzuraq/esdoc.git#bcd3f55bada45f0555f491cc3789c4dc3970d703"
@@ -3282,9 +3282,9 @@ esdoc-publish-html-plugin@latest:
     marked "0.3.19"
     taffydb "2.7.2"
 
-"esdoc-publish-module-html-plugin@git+https://github.com/pzuraq/esdoc-publish-module-html-plugin.git#fa1c2dbb20521f5dc477a764ab03272fb74f7d37":
+"esdoc-publish-module-html-plugin@https://github.com/pzuraq/esdoc-publish-module-html-plugin.git#fa1c2dbb20521f5dc477a764ab03272fb74f7d37":
   version "0.0.12"
-  resolved "git+https://github.com/pzuraq/esdoc-publish-module-html-plugin.git#fa1c2dbb20521f5dc477a764ab03272fb74f7d37"
+  resolved "https://github.com/pzuraq/esdoc-publish-module-html-plugin.git#fa1c2dbb20521f5dc477a764ab03272fb74f7d37"
   dependencies:
     babel-generator "6.11.4"
     cheerio "0.22.0"


### PR DESCRIPTION
Change the updatePackageJson function to properly install husky
pre-commit hook at packageJson.husky.hooks['pre-commit'], and warn
if one already exists.

Changelog for Husky: https://github.com/typicode/husky/blob/master/CHANGELOG.md
Major changes:
  * hooks defs moved in package.json from scripts.precommit to husky.hooks['pre-commit']
    (although scripts.precommit will still work, with a warning)
  * 3.0.0 requires git >= 2.13.2 (released in early 2017)
  * 2.6.0 warns if using node <= 8.6.0
  * 2.0.0: drops node 6