### PR TITLE
Permit camelCase to occur in file names

### DIFF
--- a/lib/lint.js
+++ b/lib/lint.js
@@ -55,7 +55,7 @@ function lintFileNames(paths = []) {
 
   // Accepts dasherized folder and file names. Files may begin with _ (to accomodate
   // SASS partials) and folders may begin with @ to account for scopes
-  let dasherizedNamesOnly = /^(@?[a-z0-9-]+\/)*(_?[a-z0-9-.]+)?$/;
+  let dasherizedNamesOnly = /^(@?[a-z0-9][a-zA-Z0-9-]+\/)*(_?[a-z0-9-.][a-zA-Z0-9-.]+)?$/;
 
   let matches = paths.filter(path => !path.match(dasherizedNamesOnly) && path !== '.DS_Store');
 


### PR DESCRIPTION
As the validation engine for serialization/extraction writes model
typeKeys and methods names onto the file system, we must permit file names
like:

    app/utils/schema-validations/schemas/someThing/findQuery-extract.schema.json

This allows them without allowing TitleCase, for example.