### PR TITLE
Upgrade installed husky (for addon consumers) to 4

### DIFF
--- a/blueprints/@addepar/ember-toolbox/index.js
+++ b/blueprints/@addepar/ember-toolbox/index.js
@@ -4,8 +4,18 @@ const { formatAll } = require('../../../lib/format');
 function updatePackageJson(root, ui) {
   let packageJson = fs.readJsonSync(`${root}/package.json`);
 
-  packageJson.scripts = packageJson.scripts || {};
+  packageJson = updateHuskyInPackageJson(packageJson, ui);
 
+  packageJson.scripts = packageJson.scripts || {};
+  packageJson.scripts.lint = 'ember adde-lint';
+  packageJson.scripts['lint:js'] = 'ember adde-lint --javascript';
+  packageJson.scripts['lint:sass'] = 'ember adde-lint --sass';
+  packageJson.scripts['lint:files'] = 'ember adde-lint --file-names';
+
+  fs.writeJsonSync(`${root}/package.json`, packageJson);
+}
+
+function updateHuskyInPackageJson(packageJson, ui) {
   packageJson.husky = packageJson.husky || {};
   packageJson.husky.hooks = packageJson.husky.hooks || {};
   if (packageJson.husky.hooks['pre-commit']) {
@@ -20,12 +30,7 @@ function updatePackageJson(root, ui) {
     packageJson.husky.hooks['pre-commit'] = 'ember adde-pre-commit';
   }
 
-  packageJson.scripts.lint = 'ember adde-lint';
-  packageJson.scripts['lint:js'] = 'ember adde-lint --javascript';
-  packageJson.scripts['lint:sass'] = 'ember adde-lint --sass';
-  packageJson.scripts['lint:files'] = 'ember adde-lint --file-names';
-
-  fs.writeJsonSync(`${root}/package.json`, packageJson);
+  return packageJson;
 }
 
 function updateTravisYml(root) {
@@ -50,7 +55,7 @@ module.exports = {
     updateTravisYml(root);
 
     return this.addPackagesToProject([
-      { name: 'husky', target: '^3.0.3' },
+      { name: 'husky', target: '^4.2.1' },
       { name: '@addepar/eslint-config' },
       { name: '@addepar/prettier-config' },
       { name: '@addepar/sass-lint-config' },


### PR DESCRIPTION
Builds on #38. This makes it so that consumers that install the addon will have the latest [husky](https://github.com/typicode/husky) (^4) installed, instead of ^3. The only breaking change in Husky @ 4 is the drop of Node 8 support.

Should be reviewed after #38. The unique diff is (currently) in commit 03b9b70