### PR TITLE
Upgrade prettier to ^1.19.1 from ^1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "execa": "^0.10.0",
     "fs-extra": "^5.0.0",
     "lint-staged": "^7.0.4",
-    "prettier": "^1.12.0",
+    "prettier": "^1.19.1",
     "sass-lint": "^1.12.1",
     "walk-sync": "^0.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8156,10 +8156,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@^1.12.0:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^23.6.0:
   version "23.6.0"


### PR DESCRIPTION
Change the floating version range to ensure that consumers use prettier `^1.19.1`.

The 1.19 release of prettier, despite that it is only a minor version number change, is actually quite a significant one. Full changelog is [here](https://prettier.io/blog/2019/11/09/1.19.0.html).

The most notable changes are to the [Handlebars formatter](https://prettier.io/blog/2019/11/09/1.19.0.html#handlebars) — it not works well for ember hbs files.

**Update**: The description above is not correct — this addon attempts to use the consumer-installed version of prettier (as of #30). So the change in this PR will only affect consumers that *don't* have their own explicit dependency on prettier.