### PR TITLE
Merge pull request #44 from Addepar/bantic/eslint-filter-nonexistent-paths

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const execa = require('execa');
 const lint = require('./lint');
+const fs = require('fs-extra');
 
 const STANDARD_APP_FILES = ['index.js', 'ember-cli-build.js', 'testem.js'];
 const STANDARD_APP_PATHS = [
@@ -28,6 +29,8 @@ function formatAll(ui, paths = []) {
     eslintPaths.push(...STANDARD_APP_FILES);
     eslintPaths.push(...STANDARD_APP_PATHS);
   }
+
+  eslintPaths = eslintPaths.filter(path => fs.existsSync(path));
 
   let prettierPath = require.resolve('prettier/bin-prettier');
   let parentNodePath = path.resolve(path.join(path.basename(__filename), '../node_modules'));

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -76,6 +76,8 @@ function lintJavascript(paths = []) {
     paths = STANDARD_JS_PATHS.concat(STANDARD_APP_FILES);
   }
 
+  paths = paths.filter(path => fs.existsSync(path));
+
   let parentNodePath = path.resolve(path.join(path.basename(__filename), '../node_modules'));
   let eslintPath = require.resolve('eslint/bin/eslint', { paths: [parentNodePath] });
 


### PR DESCRIPTION
In eslint v5, linting nonexistent files became a fatal error,
see https://eslint.org/docs/user-guide/migrating-to-5.0.0#nonexistent-files.

Filter out these nonexistent paths so that we unblock the ability for
consumers to use eslint 5+.