### PR TITLE
[WEBCORE-784] filename-lint files in known ember-app dirs

### DIFF
--- a/.lint-staged.config.js
+++ b/.lint-staged.config.js
@@ -14,7 +14,7 @@ const parentNodePath = path.resolve(path.join(path.basename(__filename), '../nod
 const eslintPath = require.resolve('eslint/bin/eslint', { paths: [parentNodePath] });
 const sassLintPath = require.resolve('sass-lint/bin/sass-lint');
 const sassLintConfig = require.resolve('@addepar/sass-lint-config/config.yml');
-// const addeLintFileNamesPath = path.resolve(__dirname, './bin/adde-lint-file-names.js');
+const addeLintFileNamesPath = path.resolve(__dirname, './bin/adde-lint-file-names.js');
 
 module.exports = {
   // Use prettier to reformat all these file types
@@ -28,5 +28,5 @@ module.exports = {
 
   // Check the file-name for all changed files
   // [WEBCORE-784] temporarily disable filename linting
-  // '*': addeLintFileNamesPath,
+  '*': addeLintFileNamesPath,
 };

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ Addepar Ember Toolbox provides a number of commands for linting and ensuring
 consistent style of Ember projects.
 
 - `ember adde-lint --javascript --sass --file-names`: Runs our linting checks against
-  the specified files. If no files are specified, runs them against the entire repo.
+  the specified files. If no files are specified, runs them against the entire repo. Using adde-lint to line filenames is deprecated, use `adde-lint-file-names` instead.
 - `ember adde-format`: Formats the files specified, or if none are specified formats
   the entire repo.
-- `ember adde-pre-commit`: Runs our formatting and linting checks against staged
+- `ember adde-pre-commit`: Deprecated, use adde-pre-commit bin script instead.
+- `adde-pre-commit`: [bin script](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#bin) that Runs our formatting and linting checks against staged
   changes
+- `adde-lint-file-names`: [bin script](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#bin) provided by this package that lints the passed (via command line) filepaths
+-
 
 Installing this addon will also add styleguides as dependencies, set up a pre-commit
 hook to format/lint changed files before commits using [Husky](https://github.com/typicode/husky/),
@@ -38,3 +41,43 @@ ember install @addepar/ember-toolbox
 - `ember build`
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
+
+## Linting File Names
+
+`adde-lint-file-names` lints the file names that are passed on the command line. File names must be passed as absolute paths.
+
+The file name linting:
+
+- first strips off the `process.cwd()`, which is assumed to be the ember app root directory
+- excludes files that are not in typical Ember-app directory-layout spots (see below)
+- Checks each remaining filepath against a regex
+
+### Lint Filename Regex
+
+See the `lib/lint-file-names.js` file for full details.
+The rules regarding filename linting are:
+
+- directories must start with lowercase alphanumeric (with optional starting "@"),
+- filenames must start with either lowercase alphanumeric or "\_","-" or "."
+- filenames cannot include "\_" except for the first character
+
+```
+Bad examples:
+_badDir/xyz.js (dir doesn't start with alphanumeric)
+BadDir/xyz.js (dir starts with capital)
+okDir/Bad.js (file starts with capital)
+okDir/Bad.js (file starts with capital)
+okDir/bad_file.js (file includes _ after first character)
+```
+
+```
+Good examples:
+ok/.file.js
+ok/-file.js
+ok/ok-file.js
+ok/\_file.js
+ok/file.js
+@ok/file.js
+```
+
+To try the regex interactively, visit https://regexr.com/5tn2c.

--- a/lib/lint-file-names.js
+++ b/lib/lint-file-names.js
@@ -1,11 +1,34 @@
-const execa = require('execa');
 const path = require('path');
 
-function getProjectRoot() {
-  let cmd = 'git rev-parse --show-toplevel';
-  return execa.command(cmd).then(({ stdout }) => {
-    return stdout.toString().trim();
-  });
+const STANDARD_APP_FILES = ['index.js', 'ember-cli-build.js', 'testem.js'];
+const STANDARD_APP_PATHS = [
+  'addon',
+  'addon-test-support',
+  'app',
+  'config',
+  'lib',
+  'server',
+  'test-support',
+  'tests',
+];
+
+function getLintRoot() {
+  // filename linting behavior prior to v0.8.0 was to consider only filenames that were
+  // in an Ember-app directory (or were an Ember-app file) in the Ember-app root.
+  // v0.8.0 broke that behavior by looking at the *git repository* root instead (as well as
+  // skipping the Ember-app-only path filtering).
+  // When Husky runs lint-file-names, Husky will change directories to the Husky "root", which
+  // will be the Ember-app root (specifically: the Husky root is wherever the package.json with the husky.hooks
+  // exists).
+  // See [WEBCORE-784] for more
+  return Promise.resolve(process.cwd());
+}
+
+function filepathIsEmberAppPath(filepath) {
+  return (
+    STANDARD_APP_FILES.includes(filepath) ||
+    STANDARD_APP_PATHS.some(standardPath => filepath.startsWith(standardPath))
+  );
 }
 
 function absoluteToRelative(root, absPath) {
@@ -17,14 +40,18 @@ function absoluteToRelative(root, absPath) {
 
 // directories must start with lowercase alphanumeric (with optional starting "@"),
 // filenames must start with either lowercase alphanumeric or "_","-" or "."
+// filenames cannot include "_" except for the first character
 // Bad examples:
-//   _bad/xyz.js (dir doesn't start with alphanumeric)
-//   Bad/xyz.js (dir starts with capital)
-//   ok/Bad.js (file starts with capital)
+//   _badDir/xyz.js (dir doesn't start with alphanumeric)
+//   BadDir/xyz.js (dir starts with capital)
+//   okDir/Bad.js (file starts with capital)
+//   okDir/Bad.js (file starts with capital)
+//   okDir/bad_file.js (file includes _ after first character)
 //
 // Good examples:
 //   ok/.file.js
 //   ok/-file.js
+//   ok/ok-file.js
 //   ok/_file.js
 //   ok/file.js
 //   @ok/file.js
@@ -37,22 +64,22 @@ function lintFileName(relativePath) {
 }
 
 function lintFileNames(paths) {
-  return getProjectRoot().then(root => {
-    paths = paths.map(absPath => absoluteToRelative(root, absPath));
+  let root = getLintRoot();
+  paths = paths.map(absPath => absoluteToRelative(root, absPath));
+  paths = paths.filter(path => filepathIsEmberAppPath(path));
 
-    let invalid = paths.filter(path => !lintFileName(path));
+  let invalid = paths.filter(path => !lintFileName(path));
 
-    if (invalid.length > 0) {
-      return {
-        success: false,
-        message: `Found ${invalid.length} invalid filenames:\n${invalid
-          .map(name => `  - ${name}`)
-          .join('\n  ')}`,
-      };
-    } else {
-      return { success: true };
-    }
-  });
+  if (invalid.length > 0) {
+    return Promise.resolve({
+      success: false,
+      message: `Found ${invalid.length} invalid filenames:\n${invalid
+        .map(name => `  - ${name}`)
+        .join('\n  ')}`,
+    });
+  } else {
+    return Promise.resolve({ success: true });
+  }
 }
 
 module.exports = {

--- a/lib/lint-file-names.js
+++ b/lib/lint-file-names.js
@@ -16,12 +16,13 @@ function getLintRoot() {
   // filename linting behavior prior to v0.8.0 was to consider only filenames that were
   // in an Ember-app directory (or were an Ember-app file) in the Ember-app root.
   // v0.8.0 broke that behavior by looking at the *git repository* root instead (as well as
-  // skipping the Ember-app-only path filtering).
+  // skipping the Ember-app-only path filtering) -- for repos where the ember app is not at the top-level,
+  // this was a breaking change.
   // When Husky runs lint-file-names, Husky will change directories to the Husky "root", which
   // will be the Ember-app root (specifically: the Husky root is wherever the package.json with the husky.hooks
   // exists).
   // See [WEBCORE-784] for more
-  return Promise.resolve(process.cwd());
+  return process.cwd();
 }
 
 function filepathIsEmberAppPath(filepath) {
@@ -71,12 +72,12 @@ function lintFileNames(paths) {
   let invalid = paths.filter(path => !lintFileName(path));
 
   if (invalid.length > 0) {
-    return Promise.resolve({
-      success: false,
-      message: `Found ${invalid.length} invalid filenames:\n${invalid
-        .map(name => `  - ${name}`)
-        .join('\n  ')}`,
-    });
+    let message = [
+      `Found ${invalid.length} invalid filenames`,
+      'For help, see https://git.io/JGoA3',
+      ...invalid.map(name => ` - ${name}`),
+    ].join('\n');
+    return Promise.resolve({ success: false, message });
   } else {
     return Promise.resolve({ success: true });
   }

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -34,6 +34,11 @@ function runLint(name, options) {
     });
 }
 
+// This function is deprecated.
+// Filename linting is now handled by lint-file-names.js.
+// This function still exists (for the time being) to handle
+// the `ember adde-lint --file-names` invocation, which calls this
+// function.
 function lintFileNames(paths = []) {
   let root = process.cwd();
 


### PR DESCRIPTION
This restores behavior from the pre-0.8.0 versions of ember-toolbox. Fixes [WEBCORE-784].

In those versions, the filename-linting would be applied only to files that are in `${process.cwd()}/<knownEmberAppDir | knownEmberAppFile>`, where `process.cwd()` is the ember-app root (the location of the package.json file that lists `@addepar/ember-toolbox` as a dependency), and known ember dirs and files include:
  * `app/`
  * `addon/`
  * `tests/`
  * `index.js`
  * `ember-cli-build.js`

The 0.8.0 release inadvertently changed the filename linting to run on *all* files without restrictions, causing unwanted lint failures for awkwardly-named files that lived outside the normal ember-app directories.

This restores the behavior of the pre-0.8.0 with respect to filename-linting.

Caveat emptor, however, that the filename linting as of this change (and as it was pre-0.8.0) is not a perfect fit for monorepo/workspace repos, because it will only lint files in the ember-app root. If there are other ember-addon or ember-app packages in the monorepo that aren't at that root, they will not be linted.

For example, given this directory structure:

```
repo-root
├── ember-app-root
│   ├── app          <-- files in this dir (and, if present, addon/, tests/ lib/ etc)
                         will be filname-linted
│   │   └── app.js   <-- this file will be filename-linted
│   ├── package.json <-- this installs ember-toolbox; husky pre-commit is defined here
│   └── packages              <-- nothing in this dir will be filename-linted
│       └── another-package
│           ├── app
│           │   └── app.js
│           └── package.json
└── other-package             <-- nothing in this dir will be filename-linted
    ├── app
    │   └── app.js
    └── package.json
```

The ember-app is in `ember-app-root` (which is not the root of the repo), so only files in `ember-app-root/<knownEmberDir | knownEmberFile>` will be filename-linted. None of the other packages (in either `/repo-root/other-package/` or `/repo-root/ember-app-root/packages/`) will be filename-linted.

[WEBCORE-784]: https://addepar.atlassian.net/browse/WEBCORE-784