### PR TITLE
Support ESLint 8 (while keeping compatibility with 7) through the alternative paths to eslint binary

### DIFF
--- a/lib/lint.js
+++ b/lib/lint.js
@@ -58,7 +58,7 @@ function lintFileNames(paths = []) {
       });
   }
 
-  // Accepts dasherized folder and file names. Files may begin with _ (to accomodate
+  // Accepts dasherized folder and file names. Files may begin with _ (to accommodate
   // SASS partials) and folders may begin with @ to account for scopes
   let dasherizedNamesOnly = /^(@?[a-z0-9][a-zA-Z0-9-]+\/)*(_?[a-z0-9-.][a-zA-Z0-9-.]+)?$/;
 
@@ -84,7 +84,16 @@ function lintJavascript(paths = []) {
   paths = paths.filter(path => fs.existsSync(path));
 
   let parentNodePath = path.resolve(path.join(path.basename(__filename), '../node_modules'));
-  let eslintPath = require.resolve('eslint/bin/eslint', { paths: [parentNodePath] });
+
+  let eslintPath;
+  try {
+    eslintPath = require.resolve('eslint/bin/eslint', { paths: [parentNodePath] });
+  } catch (err) {
+    console.log('\n');
+    console.warn(err);
+    console.log('\nTrying alternative path to eslint..');
+    eslintPath = require.resolve('.bin/eslint', { paths: [parentNodePath] });
+  }
 
   return runLint('javascript', {
     command: eslintPath,

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -85,14 +85,25 @@ function lintJavascript(paths = []) {
 
   let parentNodePath = path.resolve(path.join(path.basename(__filename), '../node_modules'));
 
+  /**
+   * There are several consumers of this package that still rely on ESLint 7.
+   *
+   * After bumping ESLint to 8 in `ember-toolbox` proper, ESLint 7 no longer
+   * resolves.
+   *
+   * The code below ensures that `ember-toolbox` can work for both ESLint 7 and 8,
+   * and gives us time to upgrade ESLint 7 users, as well.
+   */
   let eslintPath;
   try {
-    eslintPath = require.resolve('eslint/bin/eslint', { paths: [parentNodePath] });
+    // ESLint 8
+    eslintPath = require.resolve('.bin/eslint', { paths: [parentNodePath] });
   } catch (err) {
+    // assuming legacy ESLint 7
     console.log('\n');
     console.warn(err);
-    console.log('\nTrying alternative path to eslint..');
-    eslintPath = require.resolve('.bin/eslint', { paths: [parentNodePath] });
+    console.log('\nTrying alternative path to eslint (assuming version 7) ..');
+    eslintPath = require.resolve('eslint/bin/eslint', { paths: [parentNodePath] });
   }
 
   return runLint('javascript', {


### PR DESCRIPTION
This PR updates the path to `eslint` binary to match ESLint 8 behavior, thus fixing the error found during upgrading consumer projects to `eslint 8.2`

For compatibility, the old path will be retried if the new path fails (see code comment for the details).