### PR TITLE
Few more places where the old eslint path resolve was happening

### DIFF
--- a/.lint-staged.config.js
+++ b/.lint-staged.config.js
@@ -11,7 +11,27 @@ const path = require('path');
 
 const prettierPath = require.resolve('prettier/bin-prettier');
 const parentNodePath = path.resolve(path.join(path.basename(__filename), '../node_modules/'));
-const eslintPath = require.resolve('eslint/bin/eslint', { paths: [parentNodePath] });
+
+/**
+ * There are several consumers of this package that still rely on ESLint 7.
+ *
+ * After bumping ESLint to 8 in `ember-toolbox` proper, ESLint 7 no longer
+ * resolves.
+ *
+ * The code below ensures that `ember-toolbox` can work for both ESLint 7 and 8,
+ * and gives us time to upgrade ESLint 7 users, as well.
+ */
+let eslintPath;
+try {
+  // ESLint 8
+  eslintPath = require.resolve('.bin/eslint', { paths: [parentNodePath] });
+} catch (err) {
+  // assuming legacy ESLint 7
+  console.log('\n');
+  console.warn(err);
+  console.log('\nTrying alternative path to eslint (assuming version 7) ..');
+  eslintPath = require.resolve('eslint/bin/eslint', { paths: [parentNodePath] });
+}
 const sassLintPath = require.resolve('sass-lint/bin/sass-lint');
 const sassLintConfig = require.resolve('@addepar/sass-lint-config/config.yml');
 const addeLintFileNamesPath = path.resolve(__dirname, './bin/adde-lint-file-names.js');

--- a/lib/format.js
+++ b/lib/format.js
@@ -34,7 +34,26 @@ function formatAll(ui, paths = []) {
 
   let prettierPath = require.resolve('prettier/bin-prettier');
   let parentNodePath = path.resolve(path.join(path.basename(__filename), '../node_modules'));
-  let eslintPath = require.resolve('eslint/bin/eslint', { paths: [parentNodePath] });
+  /**
+   * There are several consumers of this package that still rely on ESLint 7.
+   *
+   * After bumping ESLint to 8 in `ember-toolbox` proper, ESLint 7 no longer
+   * resolves.
+   *
+   * The code below ensures that `ember-toolbox` can work for both ESLint 7 and 8,
+   * and gives us time to upgrade ESLint 7 users, as well.
+   */
+  let eslintPath;
+  try {
+    // ESLint 8
+    eslintPath = require.resolve('.bin/eslint', { paths: [parentNodePath] });
+  } catch (err) {
+    // assuming legacy ESLint 7
+    console.log('\n');
+    console.warn(err);
+    console.log('\nTrying alternative path to eslint (assuming version 7) ..');
+    eslintPath = require.resolve('eslint/bin/eslint', { paths: [parentNodePath] });
+  }
 
   ui.startProgress('formatting all files, this could take a while...');
 


### PR DESCRIPTION
This is a bug-fixing follow-up to #51 : 
- turned out there were 2 other places where old resolution was happening, so the fix is literally copy-paste the fallback code.

Tested with local branch at 
```
    "@addepar/ember-toolbox": "https://github.com/Addepar/addepar-ember-toolbox.git#e2685f0ce991d47d9607591a4794dc22c3c38046",

```

the job `yarn adde-pre-commit` completed successfully:
```
❯ yarn adde-pre-commit                                
yarn run v1.22.17
$ /Volumes/code/Iverson/iverson/node_modules/.bin/adde-pre-commit
✔ Preparing...
✔ Running tasks...
✔ Applying modifications...
✔ Cleaning up...
✨  Done in 6.44s.
```